### PR TITLE
Feature/error handling

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,16 +1,18 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
 WORKDIR /app
 
-# copy csproj and restore as distinct layers
+# copy csproj and call `restore` as a distinct layer
 COPY *.sln .
 COPY samples/ApiV3/*.csproj ./samples/ApiV3/
 COPY samples/Data/*.csproj ./samples/Data/
 COPY src/Dapper.Logging/*.csproj ./src/Dapper.Logging/
+COPY tests/Dapper.Logging.Tests/*.csproj ./tests/Dapper.Logging.Tests/
 RUN dotnet restore --verbosity normal
 
-# copy everything else and build app
+# copy the actual sources and build app
 COPY samples/. ./samples/
 COPY src/. ./src/
+COPY strong-name.snk .
 WORKDIR /app/samples/ApiV3
 RUN dotnet publish -c Release -o out
 

--- a/src/Dapper.Logging/Dapper.Logging.csproj
+++ b/src/Dapper.Logging/Dapper.Logging.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>0.4.2.0</AssemblyVersion>
-    <Version>0.4.2.0</Version>
+    <AssemblyVersion>0.4.3.0</AssemblyVersion>
+    <Version>0.4.3.0</Version>
     <Authors>Anton Hryzodub</Authors>
     <Company />
     <Copyright>Anton Hryzodub</Copyright>
@@ -13,8 +13,8 @@
     <RepositoryUrl>https://github.com/hryz/Dapper.Logging</RepositoryUrl>
     <PackageTags>Dapper Logging</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>0.4.2.0</PackageVersion>
-    <PackageReleaseNotes>Made the assembly strong-name</PackageReleaseNotes>
+    <PackageVersion>0.4.3.0</PackageVersion>
+    <PackageReleaseNotes>Log failed queries, log null parameters explicitly</PackageReleaseNotes>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/src/Dapper.Logging/Hooks/WrappedCommand.cs
+++ b/src/Dapper.Logging/Hooks/WrappedCommand.cs
@@ -28,50 +28,80 @@ namespace Dapper.Logging.Hooks
         protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
         {
             var sw = Stopwatch.StartNew();
-            var reader = _command.ExecuteReader(behavior);
-            _hooks.CommandExecuted(this, _context, sw.ElapsedMilliseconds);
-            return reader;
+            try
+            {
+                return _command.ExecuteReader(behavior);
+            }
+            finally
+            {
+                _hooks.CommandExecuted(this, _context, sw.ElapsedMilliseconds);
+            }
         }
 
         protected override async Task<DbDataReader> ExecuteDbDataReaderAsync(
             CommandBehavior behavior, CancellationToken cancellationToken)
         {
             var sw = Stopwatch.StartNew();
-            var reader = await _command.ExecuteReaderAsync(behavior, cancellationToken);
-            _hooks.CommandExecuted(this, _context, sw.ElapsedMilliseconds);
-            return reader;
+            try
+            {
+                return await _command.ExecuteReaderAsync(behavior, cancellationToken);
+            }
+            finally
+            {
+                _hooks.CommandExecuted(this, _context, sw.ElapsedMilliseconds);
+            }
         }
 
         public override int ExecuteNonQuery()
         {
             var sw = Stopwatch.StartNew();
-            var result = _command.ExecuteNonQuery();
-            _hooks.CommandExecuted(this, _context, sw.ElapsedMilliseconds);
-            return result;
+            try
+            {
+                return _command.ExecuteNonQuery();
+            }
+            finally
+            {
+                _hooks.CommandExecuted(this, _context, sw.ElapsedMilliseconds);
+            }
         }
 
         public override async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
         {
             var sw = Stopwatch.StartNew();
-            var result = await _command.ExecuteNonQueryAsync(cancellationToken);
-            _hooks.CommandExecuted(this, _context, sw.ElapsedMilliseconds);
-            return result;
+            try
+            {
+                return await _command.ExecuteNonQueryAsync(cancellationToken);
+            }
+            finally
+            {
+                _hooks.CommandExecuted(this, _context, sw.ElapsedMilliseconds);
+            }
         }
 
         public override object ExecuteScalar()
         {
             var sw = Stopwatch.StartNew();
-            var result = _command.ExecuteScalar();
-            _hooks.CommandExecuted(this, _context, sw.ElapsedMilliseconds);
-            return result;
+            try
+            {
+                return _command.ExecuteScalar();
+            }
+            finally
+            {
+                _hooks.CommandExecuted(this, _context, sw.ElapsedMilliseconds);
+            }
         }
 
         public override async Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
         {
             var sw = Stopwatch.StartNew();
-            var result = await _command.ExecuteScalarAsync(cancellationToken);
-            _hooks.CommandExecuted(this, _context, sw.ElapsedMilliseconds);
-            return result;
+            try
+            {
+                return await _command.ExecuteScalarAsync(cancellationToken);
+            }
+            finally
+            {
+                _hooks.CommandExecuted(this, _context, sw.ElapsedMilliseconds);
+            }
         }
 
         //other members

--- a/src/Dapper.Logging/Hooks/WrappedConnection.cs
+++ b/src/Dapper.Logging/Hooks/WrappedConnection.cs
@@ -22,22 +22,40 @@ namespace Dapper.Logging.Hooks
         public override void Close()
         {
             var sw = Stopwatch.StartNew();
-            _connection.Close();
-            _hooks.ConnectionClosed(this, _context, sw.ElapsedMilliseconds);
+            try
+            {
+                _connection.Close();
+            }
+            finally
+            {
+                _hooks.ConnectionClosed(this, _context, sw.ElapsedMilliseconds);
+            }
         }
 
         public override void Open()
         {
             var sw = Stopwatch.StartNew();
-            _connection.Open();
-            _hooks.ConnectionOpened(this, _context, sw.ElapsedMilliseconds);
+            try
+            {
+                _connection.Open();
+            }
+            finally
+            {
+                _hooks.ConnectionOpened(this, _context, sw.ElapsedMilliseconds);
+            }
         }
 
         public override async Task OpenAsync(CancellationToken cancellationToken)
         {
             var sw = Stopwatch.StartNew();
-            await _connection.OpenAsync(cancellationToken);
-            _hooks.ConnectionOpened(this, _context, sw.ElapsedMilliseconds);
+            try
+            {
+                await _connection.OpenAsync(cancellationToken);
+            }
+            finally
+            {
+                _hooks.ConnectionOpened(this, _context, sw.ElapsedMilliseconds);
+            }
         }
 
         protected override DbCommand CreateDbCommand() => 

--- a/tests/Dapper.Logging.Tests/LoggingTests.cs
+++ b/tests/Dapper.Logging.Tests/LoggingTests.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Dapper.Logging.Tests
@@ -92,6 +93,53 @@ namespace Dapper.Logging.Tests
             var connection = factory.CreateConnection();
             var cmd = connection.CreateCommand();
             cmd.ExecuteNonQuery();
+            
+            //assert
+            innerConnection.Received().CreateCommand();
+            innerCmd.Received().ExecuteNonQuery();
+            
+            logger.Messages.Should().HaveCount(1);
+            logger.Messages[0].Text.Should().Contain("query");
+            logger.Messages[0].State.Should().ContainKey("params");
+            logger.Messages[0].State["params"].Should().BeOfType<string>();
+            logger.Messages[0].State["params"].ToString().Should().Contain("id");
+            logger.Messages[0].State["params"].ToString().Should().Contain("1");
+        }
+        
+        [Fact]
+        public void Should_log_queries_with_exceptions()
+        {
+            var logger = new TestLogger<IDbConnectionFactory>();
+            var innerConnection = Substitute.For<DbConnection>();
+            var innerCmd = Substitute.For<DbCommand>();
+            var innerParams = Substitute.For<DbParameterCollection>();
+            var param = Substitute.For<DbParameter>();
+            param.ParameterName.Returns("@id");
+            param.Value.Returns("1");
+            innerParams.GetEnumerator().Returns(new []{param}.GetEnumerator());
+            innerCmd.Parameters.Returns(innerParams);
+            
+            innerCmd.ExecuteNonQuery().ThrowsForAnyArgs<Exception>(); // ⚠️
+            
+            innerConnection.CreateCommand().Returns(innerCmd);
+            var services = new ServiceCollection()
+                .AddSingleton<ILogger<IDbConnectionFactory>>(logger);
+
+            services.AddDbConnectionFactory(
+                prv => innerConnection,
+                x => x.WithLogLevel(LogLevel.Information)
+                    .WithSensitiveDataLogging(),
+                ServiceLifetime.Singleton);
+
+            var provider = services.BuildServiceProvider();
+            var factory = provider.GetRequiredService<IDbConnectionFactory>();
+            
+            var connection = factory.CreateConnection();
+            var cmd = connection.CreateCommand();
+            cmd.CommandText = "bla";
+
+            Action a = () => cmd.ExecuteNonQuery();
+            a.Should().Throw<Exception>();
             
             //assert
             innerConnection.Received().CreateCommand();


### PR DESCRIPTION
The current approach logs the queries when they are executed to include the execution time.
When a query fails to execute (broken syntax/ connection issues) the exception is thrown and the logging is not happening.
The solution proposed by @AndrewP-GH required breaking changes (extension of a public interface).
However, we can get the same effect without breaking changes.
(log failed queries with the same message template and severity as the successful ones)

Ideally, we should have a more flexible configuration, logging before and/or after the query execution, tracking of failed/succeeded queries independently, but this requires a lot of work and redesign. Maybe, I should do it in the next major version due to lots of breaking changes.

For now, having a failed query in the logs (as info message) is better than not having it at all.
Also, the exception is not handled internally (error handling is clearly a separate concern), so it's easy to correlate it with the query in logs.
